### PR TITLE
Add tables to markdown component

### DIFF
--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -190,3 +190,65 @@ export const MarkdownWithEllipsis = bind(
 )
 
 MarkdownShowListOfLinks.storyName = 'Lists of markdown links'
+
+const TABLE_TEXT = `
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------- | -------- |
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+`
+
+export const MarkdownWithTable = bind(
+  <AppShell theme={defaultTheme}>
+      <div>
+        <Title variant='headingMd'>Table</Title>
+        <Markdown>{TABLE_TEXT}</Markdown>
+      </div>
+  </AppShell>,
+)
+
+MarkdownWithTable.storyName = 'Markdown with table'
+
+const TABLE_TEXT_BROKEN = `
+Questa era una tabella rotta:
+| Voce | Dettagli | |--------------------------|----------------------------------------------------| | Titolo | Components / Markdown - Markdown with table ⋅ Storybook | | Versione di Storybook| 8.6.12 (la tua versione attuale è 6.5.16) | | Link | Visualizza qui | | Sezioni | BASICS, COMPONENTS, ActiveTag, AuthorCard, Badge, Button, Checkbox, CircularButton, Container, CourseCard, Dropdown, EditableNote, Expert Card, FeatureCard, FieldCheckboxMultiChoice, FieldProfileImage, FieldTagsInput, HorizontalScroll, LearningListItem, LocationAutocomplete, Markdown, StandardMarkdown large size, List of links, Standard Markdown Lg, AIMarkdown, Different Markdown Sizes, Different Markdown Opening links, Lists of markdown links, Markdown With Ellipsis, Markdown with table, PathCard, ProgressBar, SuggestionInput, Text, TextArea, TextInput, Title, ToggleSwitch, Tooltip, CanvasDocs || Titolo | Components / Markdown - Markdown with table ⋅ Storybook | | Versione di Storybook| 8.6.12 (la tua versione attuale è 6.5.16) | | Link | Visualizza qui | | Sezioni | BASICS, COMPONENTS, ActiveTag, AuthorCard, Badge, Button, Checkbox, CircularButton, Container, CourseCard, Dropdown, EditableNote, Expert Card, FeatureCard, FieldCheckboxMultiChoice, FieldProfileImage, FieldTagsInput, HorizontalScroll, LearningListItem, LocationAutocomplete, Markdown, StandardMarkdown large size, List of links, Standard Markdown Lg, AIMarkdown, Different Markdown Sizes, Different Markdown Opening links, Lists of markdown links, Markdown With Ellipsis, Markdown with table, PathCard, ProgressBar, SuggestionInput, Text, TextArea, TextInput, Title, ToggleSwitch, Tooltip, CanvasDocs |
+`
+
+export const MarkdownWithTableBroken = bind(
+  <AppShell theme={defaultTheme}>
+      <div>
+        <Title variant='headingMd'>Table</Title>
+        <Markdown>{TABLE_TEXT_BROKEN}</Markdown>
+      </div>
+  </AppShell>,
+)
+
+MarkdownWithTableBroken.storyName = 'Markdown with broken table'
+
+const TIME_BUTTONS_TEXT = `ciao guarda questo punto del video [00:20:00] è interessante`
+
+export const MarkdownWithTimeButtons = bind(
+  <AppShell theme={defaultTheme}>
+      <div>
+        <Title variant='headingMd'>Table</Title>
+          <Markdown
+            overrides={{
+              reactMarkdownProps: {
+                renderers: {
+                  text: (props: any) => {
+                    const text = props.children as string;
+                    const timePattern = /\[(\d{2}:\d{2}:\d{2})\]/g;
+                    const parts = text.split(timePattern);
+                    return <>{parts.map((part, index) => index % 2 === 1 ? <button style={{ backgroundColor: 'red' }} key={index}>{part}</button> : part)}</>;
+                  }
+                }
+              }
+            }}
+          >
+          {TIME_BUTTONS_TEXT}
+        </Markdown>
+      </div>
+  </AppShell>
+);
+
+MarkdownWithTimeButtons.storyName = 'Markdown with time buttons'

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -1,5 +1,6 @@
 import { AppShell, HorizontalStack, Markdown, Title, defaultTheme } from '@learnn/designn'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import styles from './markdown.module.css'
 
 export default {
   title: 'Components/Markdown',
@@ -219,6 +220,20 @@ export const MarkdownWithTableBroken = bind(
       <div>
         <Title variant='headingMd'>Table</Title>
         <Markdown>{TABLE_TEXT_BROKEN}</Markdown>
+      </div>
+  </AppShell>,
+)
+
+MarkdownWithTableBroken.storyName = 'Markdown with broken table'
+
+
+const CLASSNAME_TEXT = '# Titolo h1\n## Titolo h2\n### Titolo h3\n**Bold**\nTesto normale'
+
+export const MarkdownWithClassName = bind(
+  <AppShell theme={defaultTheme}>
+      <div>
+        <Title variant='headingMd'>Text with class name</Title>
+        <Markdown className ={styles.content}>{CLASSNAME_TEXT}</Markdown>
       </div>
   </AppShell>,
 )

--- a/apps/storybook/stories/css-modules.d.ts
+++ b/apps/storybook/stories/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+} 

--- a/apps/storybook/stories/markdown.module.css
+++ b/apps/storybook/stories/markdown.module.css
@@ -1,0 +1,11 @@
+.content > h1 {
+  margin-left: 50px;
+}
+
+.content > h2 {
+  margin-left: 40px;
+}
+
+.content > h3 {
+  margin-left: 30px;
+}

--- a/packages/designn/package.json
+++ b/packages/designn/package.json
@@ -38,7 +38,8 @@
     "@types/styled-system__theme-get": "^5.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-markdown": "^5.0.3",
+    "react-markdown": "^5.0.0",
+    "remark-gfm": "^1.0.0",
     "styled-components": "6.1.8",
     "styled-system": "^5.1.5",
     "use-places-autocomplete": "^4.0.1"

--- a/packages/designn/src/components/Markdown.tsx
+++ b/packages/designn/src/components/Markdown.tsx
@@ -33,6 +33,8 @@ export type MarkdownProps = {
   parseUrlsMethod?: (url: string) => string
   /** Maximum number of lines to show */
   maxLines?: number
+  /** External className for custom CSS */
+  className?: string
 }
 
 type LinkProps = {
@@ -51,9 +53,9 @@ const cleanMarkdownTables = (markdownText: string): string => {
   return markdownText.replace(/\|\s*\|/g, '|\n|');
 }
 
-export const Markdown = ({ children, overrides, opensInSameTabRegexes, parseUrlsMethod, maxLines, ...props }: MarkdownProps & SpaceProps & LayoutProps) => {
+export const Markdown = ({ children, overrides, opensInSameTabRegexes, parseUrlsMethod, maxLines, className, ...props }: MarkdownProps & SpaceProps & LayoutProps) => {
   return (
-    <StyledMarkdown {...props} maxLines={maxLines}>
+    <StyledMarkdown {...props} maxLines={maxLines} className={className}>
       <ReactMarkdown
         plugins={[remarkGfm]}
         renderers={{

--- a/packages/designn/src/components/Markdown.tsx
+++ b/packages/designn/src/components/Markdown.tsx
@@ -10,7 +10,7 @@ import {
 import styled from 'styled-components'
 import { Box } from './Box'
 import ReactMarkdown from 'react-markdown'
-
+import remarkGfm from 'remark-gfm'
 export type Size = 'sm' | 'md' | 'lg'
 export type ColorVariants = 'primary' | 'secondary'
 
@@ -47,10 +47,15 @@ type LinkProps = {
   };                   
 }
 
+const cleanMarkdownTables = (markdownText: string): string => {
+  return markdownText.replace(/\|\s*\|/g, '|\n|');
+}
+
 export const Markdown = ({ children, overrides, opensInSameTabRegexes, parseUrlsMethod, maxLines, ...props }: MarkdownProps & SpaceProps & LayoutProps) => {
   return (
     <StyledMarkdown {...props} maxLines={maxLines}>
       <ReactMarkdown
+        plugins={[remarkGfm]}
         renderers={{
           link: (props: LinkProps) => {
             const url = props.node.url
@@ -70,7 +75,7 @@ export const Markdown = ({ children, overrides, opensInSameTabRegexes, parseUrls
         }} 
         {...overrides?.reactMarkdownProps}
       >
-        {children}
+        {cleanMarkdownTables(children)}
       </ReactMarkdown>
     </StyledMarkdown>
   )
@@ -86,6 +91,33 @@ export const StyledMarkdown = styled(Box)<FlexboxProps & SpaceProps & BorderProp
     -webkit-line-clamp: ${p.maxLines};
     -webkit-box-orient: vertical;
   `}
+   table {
+    border-spacing: 0 !important;
+    border-collapse: collapse !important;
+    border-color: inherit !important;
+    display: block !important;
+    margin: 0 auto !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    overflow: auto !important;
+  }
+  tbody,
+  td,
+  tfoot,
+  th,
+  thead,
+  tr {
+    border-color: white !important;
+    border-style: solid !important;
+    border-width: 2px !important;
+    padding: 0.5rem;
+  }
+  th {
+    font-weight: ${p => p.theme.typography.font_weight_black} !important;
+    font-size: ${p => p.theme.typography.font_size_200} !important;
+    text-align: left !important;
+    background-color: ${p => p.theme.colors.interaction_background.flat_active} !important;
+  }
   ${p => {
     if (p.size === 'lg') {
       return `font-size: ${p.theme.typography.font_size_350};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,11 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       react-markdown:
-        specifier: ^5.0.3
+        specifier: ^5.0.0
         version: 5.0.3(@types/react@18.0.37)(react@18.2.0)
+      remark-gfm:
+        specifier: ^1.0.0
+        version: 1.0.0
       styled-components:
         specifier: 6.1.8
         version: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -4915,6 +4918,9 @@ packages:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
     engines: {node: '>=10'}
 
+  longest-streak@2.0.4:
+    resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -4973,6 +4979,9 @@ packages:
   markdown-escapes@1.0.4:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
 
+  markdown-table@2.0.0:
+    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
+
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
@@ -4985,11 +4994,32 @@ packages:
   mdast-util-definitions@4.0.0:
     resolution: {integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==}
 
+  mdast-util-find-and-replace@1.1.1:
+    resolution: {integrity: sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==}
+
   mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
 
+  mdast-util-gfm-autolink-literal@0.1.3:
+    resolution: {integrity: sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==}
+
+  mdast-util-gfm-strikethrough@0.2.3:
+    resolution: {integrity: sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==}
+
+  mdast-util-gfm-table@0.1.6:
+    resolution: {integrity: sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==}
+
+  mdast-util-gfm-task-list-item@0.1.6:
+    resolution: {integrity: sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==}
+
+  mdast-util-gfm@0.1.2:
+    resolution: {integrity: sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==}
+
   mdast-util-to-hast@10.0.1:
     resolution: {integrity: sha512-BW3LM9SEMnjf4HXXVApZMt8gLQWVNXc3jryK0nJu/rOXPOnlkUjmdkDlmxMirpbU9ILncGFIwLH/ubnWBbcdgA==}
+
+  mdast-util-to-markdown@0.6.5:
+    resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
 
   mdast-util-to-string@1.1.0:
     resolution: {integrity: sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==}
@@ -5042,6 +5072,24 @@ packages:
 
   microevent.ts@0.1.1:
     resolution: {integrity: sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==}
+
+  micromark-extension-gfm-autolink-literal@0.5.7:
+    resolution: {integrity: sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==}
+
+  micromark-extension-gfm-strikethrough@0.6.5:
+    resolution: {integrity: sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==}
+
+  micromark-extension-gfm-table@0.4.3:
+    resolution: {integrity: sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==}
+
+  micromark-extension-gfm-tagfilter@0.3.0:
+    resolution: {integrity: sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==}
+
+  micromark-extension-gfm-task-list-item@0.3.3:
+    resolution: {integrity: sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==}
+
+  micromark-extension-gfm@0.3.3:
+    resolution: {integrity: sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==}
 
   micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
@@ -5940,6 +5988,9 @@ packages:
 
   remark-footnotes@2.0.0:
     resolution: {integrity: sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==}
+
+  remark-gfm@1.0.0:
+    resolution: {integrity: sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==}
 
   remark-mdx@1.6.22:
     resolution: {integrity: sha512-phMHBJgeV76uyFkH4rvzCftLfKCr2RZuF+/gmVcaKrpsihyzmhXjA0BEMDaPTXG5y8qZOKPVo83NAOX01LPnOQ==}
@@ -13780,6 +13831,8 @@ snapshots:
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
 
+  longest-streak@2.0.4: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -13836,6 +13889,10 @@ snapshots:
 
   markdown-escapes@1.0.4: {}
 
+  markdown-table@2.0.0:
+    dependencies:
+      repeat-string: 1.6.1
+
   md5.js@1.3.5:
     dependencies:
       hash-base: 3.1.0
@@ -13854,6 +13911,12 @@ snapshots:
     dependencies:
       unist-util-visit: 2.0.3
 
+  mdast-util-find-and-replace@1.1.1:
+    dependencies:
+      escape-string-regexp: 4.0.0
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
+
   mdast-util-from-markdown@0.8.5:
     dependencies:
       '@types/mdast': 3.0.11
@@ -13861,6 +13924,37 @@ snapshots:
       micromark: 2.11.4
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@0.1.3:
+    dependencies:
+      ccount: 1.1.0
+      mdast-util-find-and-replace: 1.1.1
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@0.2.3:
+    dependencies:
+      mdast-util-to-markdown: 0.6.5
+
+  mdast-util-gfm-table@0.1.6:
+    dependencies:
+      markdown-table: 2.0.0
+      mdast-util-to-markdown: 0.6.5
+
+  mdast-util-gfm-task-list-item@0.1.6:
+    dependencies:
+      mdast-util-to-markdown: 0.6.5
+
+  mdast-util-gfm@0.1.2:
+    dependencies:
+      mdast-util-gfm-autolink-literal: 0.1.3
+      mdast-util-gfm-strikethrough: 0.2.3
+      mdast-util-gfm-table: 0.1.6
+      mdast-util-gfm-task-list-item: 0.1.6
+      mdast-util-to-markdown: 0.6.5
     transitivePeerDependencies:
       - supports-color
 
@@ -13874,6 +13968,15 @@ snapshots:
       unist-util-generated: 1.1.6
       unist-util-position: 3.1.0
       unist-util-visit: 2.0.3
+
+  mdast-util-to-markdown@0.6.5:
+    dependencies:
+      '@types/unist': 2.0.6
+      longest-streak: 2.0.4
+      mdast-util-to-string: 2.0.0
+      parse-entities: 2.0.0
+      repeat-string: 1.6.1
+      zwitch: 1.0.5
 
   mdast-util-to-string@1.1.0: {}
 
@@ -13929,6 +14032,43 @@ snapshots:
   methods@1.1.2: {}
 
   microevent.ts@0.1.1: {}
+
+  micromark-extension-gfm-autolink-literal@0.5.7:
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark-extension-gfm-strikethrough@0.6.5:
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark-extension-gfm-table@0.4.3:
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark-extension-gfm-tagfilter@0.3.0: {}
+
+  micromark-extension-gfm-task-list-item@0.3.3:
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark-extension-gfm@0.3.3:
+    dependencies:
+      micromark: 2.11.4
+      micromark-extension-gfm-autolink-literal: 0.5.7
+      micromark-extension-gfm-strikethrough: 0.6.5
+      micromark-extension-gfm-table: 0.4.3
+      micromark-extension-gfm-tagfilter: 0.3.0
+      micromark-extension-gfm-task-list-item: 0.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   micromark@2.11.4:
     dependencies:
@@ -14933,6 +15073,13 @@ snapshots:
       unist-util-visit: 2.0.3
 
   remark-footnotes@2.0.0: {}
+
+  remark-gfm@1.0.0:
+    dependencies:
+      mdast-util-gfm: 0.1.2
+      micromark-extension-gfm: 0.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   remark-mdx@1.6.22:
     dependencies:


### PR DESCRIPTION
- Downgrade react-markdown from v5.0.3 to v.5.0.0 to have compatibility with plugin for tables